### PR TITLE
Add default keybinds, and `GlobalActionContainer`

### DIFF
--- a/Kumi.Game/Database/RealmAccess.cs
+++ b/Kumi.Game/Database/RealmAccess.cs
@@ -105,10 +105,21 @@ public class RealmAccess : IDisposable
         where TModel : RealmObject
     {
         if (ThreadSafety.IsUpdateThread)
-            return Realm.All<TModel>().Where(query).AsQueryable().SubscribeForNotifications(action);
+            return Realm.All<TModel>().SubscribeForNotifications(handleSubscription);
 
         using var r = getInstance();
-        return r.All<TModel>().Where(query).AsQueryable().SubscribeForNotifications(action);
+        return r.All<TModel>().SubscribeForNotifications(handleSubscription);
+
+        void handleSubscription(IRealmCollection<TModel> sender, ChangeSet? changes)
+        {
+            if (changes == null)
+                return;
+
+            if (sender.Where(query).Any())
+                return;
+            
+            action(sender, changes);
+        }
     }
 
     public bool Compact()

--- a/Kumi.Game/Input/Bindings/Keybind.cs
+++ b/Kumi.Game/Input/Bindings/Keybind.cs
@@ -16,6 +16,7 @@ public class Keybind : RealmObject, IHasGuidPrimaryKey
     /// <summary>
     /// The type of keybind this is.
     /// </summary>
+    [Ignored]
     public KeybindType Type
     {
         get => (KeybindType)TypeInt;

--- a/Kumi.Game/Input/Bindings/Keybind.cs
+++ b/Kumi.Game/Input/Bindings/Keybind.cs
@@ -1,0 +1,79 @@
+﻿using JetBrains.Annotations;
+using Kumi.Game.Database;
+using osu.Framework.Input.Bindings;
+using Realms;
+
+namespace Kumi.Game.Input;
+
+/// <summary>
+/// A model that stores all of the keybinds for the game.
+/// </summary>
+public class Keybind : RealmObject, IHasGuidPrimaryKey
+{
+    [PrimaryKey]
+    public Guid ID { get; }
+
+    /// <summary>
+    /// The type of keybind this is.
+    /// </summary>
+    public KeybindType Type
+    {
+        get => (KeybindType)TypeInt;
+        set => TypeInt = (int)value;
+    }
+    
+    /// <summary>
+    /// The key combination of this keybind.
+    /// </summary>
+    [Ignored]
+    public KeyCombination KeyCombination
+    {
+        get => new KeyCombination(KeyCombinationString);
+        set => KeyCombinationString = value.ToString();
+    }
+
+    /// <summary>
+    /// The action that this keybind is bound to.
+    /// </summary>
+    public int Action { get; set; }
+    
+    [MapTo(nameof(KeyCombinationString))]
+    public string KeyCombinationString { get; set; }
+    
+    [MapTo(nameof(Type))]
+    public int TypeInt { get; set; }
+    
+    public Keybind(KeybindType type, int action, KeyCombination keyCombination)
+    {
+        ID = Guid.NewGuid();
+        Type = type;
+        Action = action;
+        KeyCombination = keyCombination;
+    }
+
+    [UsedImplicitly]
+    private Keybind()
+    {
+    }
+    
+    /// <summary>
+    /// Gets the action of this keybind based on the type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public T GetAction<T>() where T : Enum
+    {
+        return Type switch
+        {
+            KeybindType.Global => (T) Enum.ToObject(typeof(GlobalAction), Action),
+            KeybindType.Gameplay => (T) Enum.ToObject(typeof(GameplayAction), Action),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}
+
+public enum KeybindType
+{
+    Global,
+    Gameplay
+}

--- a/Kumi.Game/Input/Bindings/KeybindStore.cs
+++ b/Kumi.Game/Input/Bindings/KeybindStore.cs
@@ -12,18 +12,8 @@ public class KeybindStore : RealmBackedDefaultStore<Keybind>
     {
     }
     
-    [Resolved]
-    private GlobalKeybindContainer keybindContainer { get; set; }
-    
-    public override IEnumerable<Keybind> GetDefaultValues()
+    public override void AssignDefaults()
     {
-        var keybinds = new List<Keybind>();
-        
-        foreach (var binding in keybindContainer.DefaultKeyBindings)
-        {
-            keybinds.Add(new Keybind(KeybindType.Global, (int)binding.Action, binding.KeyCombination));
-        }
-        
-        return keybinds;
+        return;
     }
 }

--- a/Kumi.Game/Input/Bindings/KeybindStore.cs
+++ b/Kumi.Game/Input/Bindings/KeybindStore.cs
@@ -1,0 +1,29 @@
+﻿using Kumi.Game.Database;
+using osu.Framework.Allocation;
+
+namespace Kumi.Game.Input;
+
+/// <summary>
+/// A store that stores all of the keybinds for the game.
+/// </summary>
+public class KeybindStore : RealmBackedDefaultStore<Keybind>
+{
+    public KeybindStore(RealmAccess realmAccess) : base(realmAccess)
+    {
+    }
+    
+    [Resolved]
+    private GlobalKeybindContainer keybindContainer { get; set; }
+    
+    public override IEnumerable<Keybind> GetDefaultValues()
+    {
+        var keybinds = new List<Keybind>();
+        
+        foreach (var binding in keybindContainer.DefaultKeyBindings)
+        {
+            keybinds.Add(new Keybind(KeybindType.Global, (int)binding.Action, binding.KeyCombination));
+        }
+        
+        return keybinds;
+    }
+}

--- a/Kumi.Game/Input/Bindings/RealmBackedKeyBindingContainer.cs
+++ b/Kumi.Game/Input/Bindings/RealmBackedKeyBindingContainer.cs
@@ -1,0 +1,45 @@
+﻿using Kumi.Game.Database;
+using osu.Framework.Allocation;
+using osu.Framework.Input.Bindings;
+
+namespace Kumi.Game.Input;
+
+/// <summary>
+/// A key binding container that is backed by a Realm database.
+/// </summary>
+/// <typeparam name="T">The actions this container handles.</typeparam>
+public abstract partial class RealmBackedKeyBindingContainer<T> : KeyBindingContainer<T>
+    where T : struct
+{
+    /// <summary>
+    /// The type of keybinds this container handles.
+    /// </summary>
+    public KeybindType Type { get; }
+    
+    public RealmBackedKeyBindingContainer(
+        SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None,
+        KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
+        : base(simultaneousMode, matchingMode)
+    {
+        
+    }
+    
+    [Resolved]
+    private RealmAccess realm { get; set; }
+
+    protected override void LoadComplete()
+    {
+        realm.Subscribe<Keybind>(b => b.Type == Type, (sender, changes) =>
+        {
+            if (changes == null)
+                return;
+            
+            ReloadMappings(sender.AsEnumerable());
+        });
+    }
+    
+    protected override void ReloadMappings() => ReloadMappings(realm.Run(r => r.All<Keybind>().Where(b => b.Type == Type)));
+
+    private void ReloadMappings(IEnumerable<Keybind> keybinds) =>
+        KeyBindings = keybinds.Where(b => b.Type == Type).Select(b => new KeyBinding(b.KeyCombination, b.Action));
+}

--- a/Kumi.Game/Input/Bindings/RealmBackedKeyBindingContainer.cs
+++ b/Kumi.Game/Input/Bindings/RealmBackedKeyBindingContainer.cs
@@ -8,7 +8,7 @@ namespace Kumi.Game.Input;
 /// A key binding container that is backed by a Realm database.
 /// </summary>
 /// <typeparam name="T">The actions this container handles.</typeparam>
-public abstract partial class RealmBackedKeyBindingContainer<T> : KeyBindingContainer<T>
+public abstract partial class RealmBackedKeyBindingContainer<T> : KeyBindingContainer<T>, IStoreDefaults<Keybind>
     where T : struct
 {
     /// <summary>
@@ -42,4 +42,6 @@ public abstract partial class RealmBackedKeyBindingContainer<T> : KeyBindingCont
 
     private void ReloadMappings(IEnumerable<Keybind> keybinds) =>
         KeyBindings = keybinds.Where(b => b.Type == Type).Select(b => new KeyBinding(b.KeyCombination, b.Action));
+    
+    public IEnumerable<Keybind> GetDefaultValues() => DefaultKeyBindings.Select(b => new Keybind(Type, (int)b.Action, b.KeyCombination));
 }

--- a/Kumi.Game/Input/Bindings/RealmBackedKeyBindingContainer.cs
+++ b/Kumi.Game/Input/Bindings/RealmBackedKeyBindingContainer.cs
@@ -8,7 +8,7 @@ namespace Kumi.Game.Input;
 /// A key binding container that is backed by a Realm database.
 /// </summary>
 /// <typeparam name="T">The actions this container handles.</typeparam>
-public abstract partial class RealmBackedKeyBindingContainer<T> : KeyBindingContainer<T>, IStoreDefaults<Keybind>
+public abstract partial class RealmBackedKeyBindingContainer<T> : KeyBindingContainer<T>, IHasDefaults<Keybind>
     where T : struct
 {
     /// <summary>

--- a/Kumi.Game/Input/GameplayAction.cs
+++ b/Kumi.Game/Input/GameplayAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Kumi.Game.Input;
+
+public enum GameplayAction
+{
+    
+}

--- a/Kumi.Game/Input/GlobalAction.cs
+++ b/Kumi.Game/Input/GlobalAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Kumi.Game.Input;
+
+public enum GlobalAction
+{
+    
+}

--- a/Kumi.Game/Input/GlobalKeybindContainer.cs
+++ b/Kumi.Game/Input/GlobalKeybindContainer.cs
@@ -1,0 +1,12 @@
+﻿using osu.Framework.Input.Bindings;
+
+namespace Kumi.Game.Input;
+
+public class GlobalKeybindContainer : RealmBackedKeyBindingContainer<GlobalAction>
+{
+
+    public override IEnumerable<IKeyBinding> DefaultKeyBindings => new KeyBinding[]
+    {
+
+    };
+}

--- a/Kumi.Game/KumiGameBase.cs
+++ b/Kumi.Game/KumiGameBase.cs
@@ -71,7 +71,7 @@ public partial class KumiGameBase : osu.Framework.Game
         
         dependencies.Cache(globalKeybindContainer);
         dependencies.Cache(keybindStore = new KeybindStore(realm));
-        keybindStore.RegisterDefaults();
+        keybindStore.AssignDefaultsFor(globalKeybindContainer);
     }
 
     public override void SetHost(GameHost host)

--- a/Kumi.Game/KumiGameBase.cs
+++ b/Kumi.Game/KumiGameBase.cs
@@ -72,6 +72,7 @@ public partial class KumiGameBase : osu.Framework.Game
         dependencies.Cache(globalKeybindContainer);
         dependencies.Cache(keybindStore = new KeybindStore(realm));
         keybindStore.AssignDefaultsFor(globalKeybindContainer);
+        keybindStore.RegisterDefaults();
     }
 
     public override void SetHost(GameHost host)

--- a/Kumi.Game/KumiGameBase.cs
+++ b/Kumi.Game/KumiGameBase.cs
@@ -1,6 +1,7 @@
 ﻿using Kumi.Game.Charts;
 using Kumi.Game.Database;
 using Kumi.Game.Graphics;
+using Kumi.Game.Input;
 using Kumi.Resources;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -17,6 +18,7 @@ public partial class KumiGameBase : osu.Framework.Game
     
     private RealmAccess realm = null!;
     private ChartManager chartManager = null!;
+    private KeybindStore keybindStore = null!;
     protected Colors GameColors { get; private set; }
     protected override Container<Drawable> Content { get; }
 
@@ -47,6 +49,7 @@ public partial class KumiGameBase : osu.Framework.Game
 
         var defaultChart = new DummyWorkingChart(Audio, Textures);
         dependencies.Cache(chartManager = new ChartManager(Storage, realm, Audio, Resources, Host, defaultChart));
+        dependencies.Cache(keybindStore = new KeybindStore(realm));
         
         dependencies.Cache(GameColors = new Colors());
     }

--- a/Kumi.Game/KumiGameBase.cs
+++ b/Kumi.Game/KumiGameBase.cs
@@ -42,16 +42,36 @@ public partial class KumiGameBase : osu.Framework.Game
     private void load()
     {
         Resources.AddStore(new DllResourceStore(KumiResources.Assembly));
+        dependencies.Cache(GameColors = new Colors());
         
         dependencies.Cache(realm = new RealmAccess(Storage));
-        
         dependencies.CacheAs(Storage);
 
         var defaultChart = new DummyWorkingChart(Audio, Textures);
         dependencies.Cache(chartManager = new ChartManager(Storage, realm, Audio, Resources, Host, defaultChart));
-        dependencies.Cache(keybindStore = new KeybindStore(realm));
         
-        dependencies.Cache(GameColors = new Colors());
+        GlobalKeybindContainer globalKeybindContainer;
+        
+        base.Content.Add(new SafeAreaContainer()
+        {
+            RelativeSizeAxes = Axes.Both,
+            Child = new DrawSizePreservingFillContainer() // TODO: Add a way to change the resolution and UI scale dynamically.
+            {
+                TargetDrawSize = new Vector2(1920, 1080),
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    globalKeybindContainer = new GlobalKeybindContainer()
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                }
+            }
+        });
+        
+        dependencies.Cache(globalKeybindContainer);
+        dependencies.Cache(keybindStore = new KeybindStore(realm));
+        keybindStore.RegisterDefaults();
     }
 
     public override void SetHost(GameHost host)


### PR DESCRIPTION
For now, there's no way to add more than one type of keybind; and there are also no defaults. With due time, we'll find global actions across the game; this is just initial handling.

Relies on #4.