### PR TITLE
Add permissions to the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: dorny/test-reporter@v1.7.0
         if: success() || failure()
         with:
-          name: NUnit Tests
+          name: NUnit Tests (${{matrix.os}})
           path: Kumi.Tests/TestResults/*.trx
           reporter: dotnet-trx
       - name: Upload Artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  checks: write # Allows for the test reporter to upload its reports.
+
 jobs:
   build-test:
     name: Build and Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     name: Build and Test
     runs-on: ${{ matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 


### PR DESCRIPTION
This also fixes the name of the report, and disallows immediate failing on other matrices when one fails.