### PR TITLE
Add taskbar and login flyout

### DIFF
--- a/Kumi.Game/Graphics/Sprites/AvatarSprite.cs
+++ b/Kumi.Game/Graphics/Sprites/AvatarSprite.cs
@@ -1,0 +1,34 @@
+﻿using Kumi.Game.Online.API.Accounts;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace Kumi.Game.Graphics.Sprites;
+
+public partial class AvatarSprite : Sprite
+{
+    private readonly IUser? user;
+
+    public AvatarSprite(IUser? user)
+    {
+        this.user = user;
+
+        RelativeSizeAxes = Axes.Both;
+        FillMode = FillMode.Fit;
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(LargeTextureStore store)
+    {
+        Texture = store.Get($"http://localhost:3333/cdn/avatars/{user?.Id ?? 0}");
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        this.FadeInFromZero(200, Easing.OutQuint);
+    }
+}

--- a/Kumi.Game/Graphics/Sprites/UpdateableAvatarSprite.cs
+++ b/Kumi.Game/Graphics/Sprites/UpdateableAvatarSprite.cs
@@ -1,0 +1,24 @@
+﻿using Kumi.Game.Online.API.Accounts;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace Kumi.Game.Graphics.Sprites;
+
+public partial class UpdateableAvatarSprite : ModelBackedDrawable<APIAccount?>
+{
+    public APIAccount? Account
+    {
+        get => Model;
+        set => Model = value;
+    }
+
+    public UpdateableAvatarSprite(APIAccount? account = null)
+    {
+        Account = account;
+        Masking = true;
+        CornerRadius = 5;
+    }
+
+    protected override Drawable CreateDrawable(APIAccount? account)
+        => new AvatarSprite(account);
+}

--- a/Kumi.Game/Graphics/UserInterface/KumiButton.cs
+++ b/Kumi.Game/Graphics/UserInterface/KumiButton.cs
@@ -1,0 +1,159 @@
+﻿using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osuTK.Graphics;
+
+namespace Kumi.Game.Graphics.UserInterface;
+
+public partial class KumiButton : Button
+{
+    private readonly Container container;
+    private readonly Box background;
+    private readonly SpriteText spriteText;
+
+    private LocalisableString text;
+
+    public LocalisableString Text
+    {
+        get => text;
+        set
+        {
+            text = value;
+            spriteText.Text = text;
+        }
+    }
+
+    private Color4 backgroundColour = Color4Extensions.FromHex("F94826");
+    
+    public Color4 BackgroundColour
+    {
+        get => backgroundColour;
+        set
+        {
+            backgroundColour = value;
+            background.Colour = backgroundColour;
+        }
+    }
+    
+    private FontUsage font = KumiFonts.GetFont(weight: FontWeight.Medium, size: 14);
+    
+    public FontUsage Font
+    {
+        get => font;
+        set
+        {
+            font = value;
+            spriteText.Font = font;
+        }
+    }
+
+    private bool important;
+
+    public bool Important
+    {
+        get => important;
+        set
+        {
+            if (important == value)
+                return;
+
+            if (value)
+            {
+                BorderColour = new ColourInfo
+                {
+                    TopLeft = Color4.White.Opacity(0.25f),
+                    TopRight = Color4.White.Opacity(0.25f),
+                    BottomLeft = Color4.White.Opacity(0.1f * 0.25f),
+                    BottomRight = Color4.White.Opacity(0.1f * 0.25f)
+                };
+            }
+            else
+            {
+                BorderColour = Color4.Transparent;
+            }
+            
+            important = value;
+        }
+    }
+
+    public new float Height
+    {
+        get => container.Height;
+        set
+        {
+            container.AutoSizeAxes = Axes.None;
+            container.Padding = new MarginPadding(0);
+            container.Height = value;
+        }
+    }
+
+    public KumiButton()
+    {
+        RelativeSizeAxes = Axes.X;
+        AutoSizeAxes = Axes.Y;
+        Masking = true;
+        CornerRadius = 5;
+        BorderThickness = 1.5f;
+        BorderColour = Color4.Transparent;
+        
+        Children = new Drawable[]
+        {
+            background = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = backgroundColour
+            },
+            container = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding
+                {
+                    Vertical = 4
+                },
+                Children = new Drawable[]
+                {
+                    spriteText = new SpriteText
+                    {
+                        Text = Text,
+                        Font = font,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre
+                    }
+                }
+            }
+        };
+        
+        Enabled.BindValueChanged(e =>
+        {
+            this.FadeColour(e.NewValue ? Color4.White : Color4.White.Darken(0.5f), 100, Easing.OutQuint);
+        }, true);
+    }
+
+    protected override bool OnHover(HoverEvent e)
+    {
+        background.FadeColour(backgroundColour.Lighten(0.25f), 200, Easing.OutQuint);
+        return base.OnHover(e);
+    }
+
+    protected override void OnHoverLost(HoverLostEvent e)
+    {
+        background.FadeColour(backgroundColour, 200, Easing.OutQuint);
+        base.OnHoverLost(e);
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        if (!Enabled.Value)
+            return false;
+        
+        background.FlashColour(backgroundColour.Lighten(0.9f), 500, Easing.OutQuint);
+        return base.OnClick(e);
+    }
+}

--- a/Kumi.Game/Graphics/UserInterface/KumiCheckbox.cs
+++ b/Kumi.Game/Graphics/UserInterface/KumiCheckbox.cs
@@ -1,0 +1,108 @@
+﻿using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+
+namespace Kumi.Game.Graphics.UserInterface;
+
+public partial class KumiCheckbox : Checkbox
+{
+    private readonly SpriteText label;
+    
+    private LocalisableString labelText;
+    
+    public LocalisableString LabelText
+    {
+        get => labelText;
+        set
+        {
+            labelText = value;
+            label.Text = value;
+        }
+    }
+    
+    public KumiCheckbox()
+    {
+        RelativeSizeAxes = Axes.X;
+        AutoSizeAxes = Axes.Y;
+        
+        Children = new Drawable[]
+        {
+            label = new SpriteText
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Font = KumiFonts.GetFont(size: 14),
+                Margin = new MarginPadding
+                {
+                    Vertical = 4
+                }
+            },
+            new DrawableCheckbox(this)
+            {
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight
+            }
+        };
+    }
+
+    private partial class DrawableCheckbox : Container, IHasCurrentValue<bool>
+    {
+        private readonly Box background;
+        private readonly SpriteIcon icon;
+
+        public Bindable<bool> Current { get; set; }
+
+        public DrawableCheckbox(KumiCheckbox parent)
+        {
+            Current = new BindableBool
+            {
+                BindTarget = parent.Current
+            };
+            
+            RelativeSizeAxes = Axes.Both;
+            Masking = true;
+            CornerRadius = 5;
+            FillMode = FillMode.Fit;
+            FillAspectRatio = 1;
+
+            Children = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4Extensions.FromHex("509495")
+                },
+                icon = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Solid.Check,
+                    Size = new(16),
+                    Alpha = 0,
+                    AlwaysPresent = true
+                }
+            };
+            
+            Current.BindValueChanged(onUserChange, true);
+        }
+
+        private void onUserChange(ValueChangedEvent<bool> c)
+        {
+            if (c.NewValue)
+            {
+                background.FadeColour(Color4Extensions.FromHex("00BFFF"), 200, Easing.OutQuint);
+                icon.FadeInFromZero(200, Easing.OutQuint);
+            }
+            else
+            {
+                background.FadeColour(Color4Extensions.FromHex("121212"), 200, Easing.OutQuint);
+                icon.FadeOutFromOne(200, Easing.OutQuint);
+            }
+        }
+    }
+}

--- a/Kumi.Game/Graphics/UserInterface/KumiPasswordTextBox.cs
+++ b/Kumi.Game/Graphics/UserInterface/KumiPasswordTextBox.cs
@@ -1,0 +1,18 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+
+namespace Kumi.Game.Graphics.UserInterface;
+
+public partial class KumiPasswordTextBox : KumiTextBox
+{
+    protected override Drawable GetDrawableCharacter(char c) => new BasicTextBox.FallingDownContainer
+    {
+        AutoSizeAxes = Axes.Both,
+        Child = new SpriteText
+        {
+            Text = "•",
+            Font = KumiFonts.GetFont(size: CalculatedTextSize)
+        }
+    };
+}

--- a/Kumi.Game/Graphics/UserInterface/KumiTextBox.cs
+++ b/Kumi.Game/Graphics/UserInterface/KumiTextBox.cs
@@ -1,0 +1,72 @@
+﻿using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osuTK.Graphics;
+
+namespace Kumi.Game.Graphics.UserInterface;
+
+public partial class KumiTextBox : TextBox
+{
+    protected override float LeftRightPadding => 12;
+
+    private readonly Box background;
+
+    private readonly Color4 backgroundColor = Color4Extensions.FromHex("121212");
+    private readonly Color4 inputErrorColour = Color4Extensions.FromHex("732639");
+    
+    public KumiTextBox()
+    {
+        Masking = true;
+        CornerRadius = 5;
+        
+        AddRangeInternal(new Drawable[]
+        {
+            background = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Depth = 1,
+                Colour = backgroundColor,
+            },
+        });
+
+        TextContainer.Height = 0.75f;
+    }
+
+    protected override void NotifyInputError()
+    {
+        background.FlashColour(inputErrorColour, 200, Easing.OutQuint);
+    }
+
+    protected override void OnTextCommitted(bool textChanged)
+    {
+        base.OnTextCommitted(textChanged);
+
+        background.FlashColour(Color4Extensions.FromHex("262626"), 200, Easing.OutQuint);
+    }
+
+    protected override Drawable GetDrawableCharacter(char c) => new BasicTextBox.FallingDownContainer
+    {
+        AutoSizeAxes = Axes.Both,
+        Child = new SpriteText
+        {
+            Text = c.ToString(),
+            Font = KumiFonts.GetFont(size: 14)
+        }
+    };
+
+    protected override SpriteText CreatePlaceholder() => new BasicTextBox.FadingPlaceholderText
+    {
+        Colour = Color4Extensions.FromHex("666"),
+        Font = KumiFonts.GetFont(italics: true),
+        Anchor = Anchor.CentreLeft,
+        Origin = Anchor.CentreLeft,
+    };
+
+    protected override Caret CreateCaret() => new BasicTextBox.BasicCaret
+    {
+        CaretWidth = 2,
+        SelectionColour = Color4Extensions.FromHex("00BFFF").Opacity(0.4f)
+    };
+}

--- a/Kumi.Game/KumiGameBase.cs
+++ b/Kumi.Game/KumiGameBase.cs
@@ -3,6 +3,7 @@ using Kumi.Game.Database;
 using Kumi.Game.Graphics;
 using Kumi.Game.Input;
 using Kumi.Game.Input.Bindings;
+using Kumi.Game.Online.API;
 using Kumi.Game.Screens;
 using Kumi.Resources;
 using osu.Framework.Allocation;
@@ -26,6 +27,7 @@ public partial class KumiGameBase : osu.Framework.Game
     private KeybindStore keybindStore = null!;
 
     protected Colors GameColors { get; private set; } = null!;
+    protected IAPIConnectionProvider API { get; set; } = null!;
     protected Bindable<WorkingChart> Chart { get; private set; } = null!;
     protected KumiScreenStack ScreenStack = null!;
     protected override Container<Drawable> Content { get; }
@@ -62,6 +64,9 @@ public partial class KumiGameBase : osu.Framework.Game
         // Realm Database, Storage, and Charts
         DependencyContainer.Cache(realm = new RealmAccess(Storage!));
         DependencyContainer.CacheAs(Storage);
+
+        // TODO
+        // DependencyContainer.CacheAs(API = new APIConnection());
 
         var defaultChart = new DummyWorkingChart(Audio, Textures);
         DependencyContainer.Cache(chartManager = new ChartManager(Storage!, realm, Audio, Resources, Host, defaultChart));

--- a/Kumi.Game/Overlays/Login/LoginPanel.cs
+++ b/Kumi.Game/Overlays/Login/LoginPanel.cs
@@ -1,0 +1,99 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+
+namespace Kumi.Game.Overlays.Login;
+
+public partial class LoginPanel : Container
+{
+    public override RectangleF BoundingBox => hidden ? RectangleF.Empty : base.BoundingBox;
+
+    private LoginScreenStack formStack = null!;
+    private LoginScreen? loginScreen;
+    
+    private bool hidden;
+
+    public bool Hidden
+    {
+        get => hidden;
+        set
+        {
+            hidden = value;
+            Invalidate(Invalidation.MiscGeometry);
+        }
+    }
+
+    public LoginPanel()
+    {
+        RelativeSizeAxes = Axes.X;
+        AutoSizeAxes = Axes.Y;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Children = new Drawable[]
+        {
+            new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4Extensions.FromHex("1A1A1A")
+            },
+            new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4Extensions.FromHex("F94826"),
+                Padding = new MarginPadding(4),
+                Children = new Drawable[]
+                {
+                    new Circle
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 3,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                    },
+                    new Circle
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 3,
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                    },
+                }
+            },
+            formStack = new LoginScreenStack
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding
+                {
+                    Vertical = 16,
+                    Horizontal = 12
+                },
+            }
+        };
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        formStack.Push(loginScreen = new LoginScreen());
+    }
+
+    public override bool AcceptsFocus => true;
+
+    protected override bool OnClick(ClickEvent e) => true;
+
+    protected override void OnFocus(FocusEvent e)
+    {
+        if (loginScreen != null)
+            GetContainingInputManager().ChangeFocus(loginScreen);
+            
+        base.OnFocus(e);
+    }
+}

--- a/Kumi.Game/Overlays/Login/LoginScreen.cs
+++ b/Kumi.Game/Overlays/Login/LoginScreen.cs
@@ -1,0 +1,107 @@
+﻿using Kumi.Game.Graphics;
+using Kumi.Game.Graphics.UserInterface;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Screens;
+using osuTK;
+
+namespace Kumi.Game.Overlays.Login;
+
+public partial class LoginScreen : Screen
+{
+    private KumiTextBox username = null!;
+    private KumiTextBox password = null!;
+    
+    public LoginScreen()
+    {
+        RelativeSizeAxes = Axes.X;
+        AutoSizeAxes = Axes.Y;
+    }
+    
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        InternalChild = new FillFlowContainer
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Spacing = new Vector2(0, 8),
+            Children = new Drawable[]
+            {
+                new SpriteText
+                {
+                    Text = "SIGN IN",
+                    Font = KumiFonts.GetFont(FontFamily.Montserrat, FontWeight.SemiBold, 14)
+                },
+                username = new KumiTextBox
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 24,
+                    PlaceholderText = "Username",
+                    TabbableContentContainer = this
+                },
+                password = new KumiPasswordTextBox
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 24,
+                    PlaceholderText = "Password",
+                    TabbableContentContainer = this
+                },
+                new KumiButton
+                {
+                    Text = "Sign in",
+                    Important = true
+                },
+                new KumiCheckbox
+                {
+                    LabelText = "Remember me"
+                },
+                new FillFlowContainer
+                {
+                    Direction = FillDirection.Vertical,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Margin = new MarginPadding
+                    {
+                        Top = 8
+                    },
+                    Children = new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Text = "Don't have an account?",
+                            Font = KumiFonts.GetFont(size: 14),
+                            Colour = Color4Extensions.FromHex("666")
+                        },
+                        new ClickableContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Child = new SpriteText
+                            {
+                                Text = "Register one now!",
+                                Font = KumiFonts.GetFont(size: 14),
+                                Colour = Color4Extensions.FromHex("80DFFF")
+                            },
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    public override bool AcceptsFocus => true;
+
+    protected override bool OnClick(ClickEvent e) => true;
+
+    protected override void OnFocus(FocusEvent e)
+    {
+        Schedule(() =>
+        {
+            GetContainingInputManager().ChangeFocus(username);
+        });
+    }
+}

--- a/Kumi.Game/Overlays/Login/LoginScreenStack.cs
+++ b/Kumi.Game/Overlays/Login/LoginScreenStack.cs
@@ -1,0 +1,19 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Screens;
+
+namespace Kumi.Game.Overlays.Login;
+
+public partial class LoginScreenStack : ScreenStack
+{
+    public new Axes AutoSizeAxes
+    {
+        get => base.AutoSizeAxes;
+        set => base.AutoSizeAxes = value;
+    }
+    
+    public new MarginPadding Padding
+    {
+        get => base.Padding;
+        set => base.Padding = value;
+    }
+}

--- a/Kumi.Game/Overlays/LoginOverlay.cs
+++ b/Kumi.Game/Overlays/LoginOverlay.cs
@@ -1,0 +1,42 @@
+﻿using Kumi.Game.Overlays.Login;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace Kumi.Game.Overlays;
+
+public partial class LoginOverlay : FocusedOverlayContainer
+{
+    private LoginPanel panel = null!;
+
+    protected override bool StartHidden => true;
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Child = new Container
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Masking = true,
+            CornerRadius = 5,
+            AutoSizeDuration = 200,
+            AutoSizeEasing = Easing.OutQuint,
+            Child = panel = new LoginPanel()
+        };
+    }
+
+    protected override void PopIn()
+    {
+        panel.Hidden = false;
+        this.FadeInFromZero(200, Easing.OutQuint);
+
+        ScheduleAfterChildren(() => GetContainingInputManager().ChangeFocus(panel));
+    }
+
+    protected override void PopOut()
+    {
+        panel.Hidden = true;
+        this.FadeOutFromOne(200, Easing.OutQuint);
+    }
+}

--- a/Kumi.Game/Overlays/MusicController.cs
+++ b/Kumi.Game/Overlays/MusicController.cs
@@ -11,7 +11,7 @@ using osu.Framework.Logging;
 
 namespace Kumi.Game.Overlays;
 
-public partial class MusicController : CompositeComponent
+public partial class MusicController : CompositeDrawable
 {
     [Resolved]
     private ChartManager charts { get; set; } = null!;

--- a/Kumi.Game/Overlays/Taskbar/TaskbarButton.cs
+++ b/Kumi.Game/Overlays/Taskbar/TaskbarButton.cs
@@ -1,0 +1,75 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osuTK.Graphics;
+
+namespace Kumi.Game.Overlays.Taskbar;
+
+public abstract partial class TaskbarButton : Button
+{
+    private Box hoverBox = null!;
+
+    public required TaskbarButtonAlignment Alignment { get; init; }
+    
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        RelativeSizeAxes = Axes.Y;
+        AutoSizeAxes = Axes.X;
+        
+        Children = new Drawable[]
+        {
+            hoverBox = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4.White.Opacity(0.1f),
+                AlwaysPresent = true,
+                Alpha = 0
+            },
+            new Container
+            {
+                RelativeSizeAxes = Axes.Y,
+                AutoSizeAxes = Axes.X,
+                Padding = new MarginPadding { Horizontal = 16 },
+                Child = CreateContent()
+            }
+        };
+        
+        Enabled.BindValueChanged(e =>
+        {
+            this.FadeColour(e.NewValue ? Color4.White : Color4.White.Darken(0.5f), 100, Easing.OutQuint);
+        }, true);
+    }
+    
+    protected abstract Drawable CreateContent();
+
+    protected override bool OnHover(HoverEvent e)
+    {
+        hoverBox.FadeIn(100, Easing.OutQuint);
+        return base.OnHover(e);
+    }
+    
+    protected override void OnHoverLost(HoverLostEvent e)
+    {
+        hoverBox.FadeOut(100, Easing.OutQuint);
+        base.OnHoverLost(e);
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        if (Enabled.Value)
+            hoverBox.FlashColour(Color4.White.Opacity(0.5f), 500, Easing.OutQuint);
+        
+        return base.OnClick(e);
+    }
+}
+
+public enum TaskbarButtonAlignment
+{
+    Left,
+    Right
+}

--- a/Kumi.Game/Overlays/Taskbar/TaskbarIconButton.cs
+++ b/Kumi.Game/Overlays/Taskbar/TaskbarIconButton.cs
@@ -1,0 +1,32 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+
+namespace Kumi.Game.Overlays.Taskbar;
+
+public partial class TaskbarIconButton : TaskbarButton
+{
+    private SpriteIcon? spriteIcon;
+    
+    private IconUsage icon;
+
+    public IconUsage Icon
+    {
+        get => icon;
+        set
+        {
+            icon = value;
+
+            if (spriteIcon is { IsLoaded: true })
+                spriteIcon.Icon = value;
+        }
+    }
+
+    protected override Drawable CreateContent()
+        => spriteIcon = new SpriteIcon
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Icon = icon,
+            Size = new(20)
+        };
+}

--- a/Kumi.Game/Overlays/Taskbar/TaskbarUserButton.cs
+++ b/Kumi.Game/Overlays/Taskbar/TaskbarUserButton.cs
@@ -1,0 +1,80 @@
+﻿using Kumi.Game.Graphics;
+using Kumi.Game.Graphics.Sprites;
+using Kumi.Game.Online.API;
+using Kumi.Game.Online.API.Accounts;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+
+namespace Kumi.Game.Overlays.Taskbar;
+
+public partial class TaskbarUserButton : TaskbarButton
+{
+    private SpriteText username = null!;
+    private UpdateableAvatarSprite avatar = null!;
+
+    [BackgroundDependencyLoader(true)]
+    private void load(IAPIConnectionProvider? connection)
+    {
+        connection?.LocalAccount.BindValueChanged(a =>
+        {
+            username.Text = a.NewValue?.Username ?? "Guest";
+            avatar.Account = a.NewValue ?? new GuestAccount();
+        }, true);
+    }
+
+    protected override Drawable CreateContent()
+        => new FillFlowContainer
+        {
+            Direction = FillDirection.Horizontal,
+            RelativeSizeAxes = Axes.Y,
+            AutoSizeAxes = Axes.X,
+            Spacing = new Vector2(8f, 0),
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.X,
+                    Child = username = new SpriteText
+                    {
+                        Text = "Guest",
+                        Font = KumiFonts.GetFont(size: 14),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre
+                    },
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.X,
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            Size = new Vector2(32),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Masking = true,
+                            CornerRadius = 5,
+                            Child = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4Extensions.FromHex("1A1A1A"),
+                            }
+                        },
+                        avatar = new UpdateableAvatarSprite
+                        {
+                            Size = new Vector2(32),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre
+                        },
+                    }
+                },
+            }
+        };
+}

--- a/Kumi.Game/Overlays/TaskbarOverlay.cs
+++ b/Kumi.Game/Overlays/TaskbarOverlay.cs
@@ -12,42 +12,72 @@ public partial class TaskbarOverlay : OverlayContainer
 {
     private FillFlowContainer leftFlow = null!;
     private FillFlowContainer rightFlow = null!;
+    private Container overlayContent = null!;
+    
+    private LoginOverlay loginOverlay = null!;
     
     protected override bool StartHidden => true;
 
     [BackgroundDependencyLoader]
     private void load()
     {
-        RelativeSizeAxes = Axes.X;
-        Height = 48;
+        RelativeSizeAxes = Axes.Both;
         
         Children = new Drawable[]
         {
-            new Box
-            {
-                RelativeSizeAxes = Axes.Both,
-                Colour = Color4Extensions.FromHex("0D0D0D")
-            },
             new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 48,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4Extensions.FromHex("0D0D0D")
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = 40
+                        },
+                        Children = new Drawable[]
+                        {
+                            leftFlow = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X
+                            },
+                            rightFlow = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X,
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight
+                            }
+                        }
+                    }
+                }
+            },
+            overlayContent = new Container
             {
                 RelativeSizeAxes = Axes.Both,
                 Padding = new MarginPadding
                 {
+                    Top = 48,
                     Horizontal = 40
                 },
                 Children = new Drawable[]
                 {
-                    leftFlow = new FillFlowContainer
+                    loginOverlay = new LoginOverlay
                     {
-                        RelativeSizeAxes = Axes.Y,
-                        AutoSizeAxes = Axes.X
-                    },
-                    rightFlow = new FillFlowContainer
-                    {
-                        RelativeSizeAxes = Axes.Y,
-                        AutoSizeAxes = Axes.X,
+                        Width = 208,
+                        AutoSizeAxes = Axes.Y,
                         Anchor = Anchor.TopRight,
-                        Origin = Anchor.TopRight
+                        Origin = Anchor.TopRight,
+                        Margin = new MarginPadding { Top = 4 }
                     }
                 }
             }
@@ -62,6 +92,11 @@ public partial class TaskbarOverlay : OverlayContainer
         addButton(new TaskbarUserButton
         {
             Alignment = TaskbarButtonAlignment.Right,
+        }, () =>
+        {
+            loginOverlay.State.Value = loginOverlay.State.Value == Visibility.Visible
+                ? Visibility.Hidden
+                : Visibility.Visible;
         });
     }
 

--- a/Kumi.Game/Overlays/TaskbarOverlay.cs
+++ b/Kumi.Game/Overlays/TaskbarOverlay.cs
@@ -1,0 +1,95 @@
+﻿using Kumi.Game.Overlays.Taskbar;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+
+namespace Kumi.Game.Overlays;
+
+public partial class TaskbarOverlay : OverlayContainer
+{
+    private FillFlowContainer leftFlow = null!;
+    private FillFlowContainer rightFlow = null!;
+    
+    protected override bool StartHidden => true;
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        RelativeSizeAxes = Axes.X;
+        Height = 48;
+        
+        Children = new Drawable[]
+        {
+            new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4Extensions.FromHex("0D0D0D")
+            },
+            new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding
+                {
+                    Horizontal = 40
+                },
+                Children = new Drawable[]
+                {
+                    leftFlow = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        AutoSizeAxes = Axes.X
+                    },
+                    rightFlow = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        AutoSizeAxes = Axes.X,
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.TopRight
+                    }
+                }
+            }
+        };
+        
+        addButton(new TaskbarIconButton
+        {
+            Alignment = TaskbarButtonAlignment.Left,
+            Icon = FontAwesome.Solid.Home
+        });
+        
+        addButton(new TaskbarUserButton
+        {
+            Alignment = TaskbarButtonAlignment.Right,
+        });
+    }
+
+    protected override void PopIn()
+    {
+        this.MoveToY(0, 200, Easing.OutQuint);
+    }
+
+    protected override void PopOut()
+    {
+        this.MoveToY(-DrawHeight, 200, Easing.OutQuint);
+    }
+    
+    private void addButton(TaskbarButton button, Action? action = null)
+    {
+        button.Action = action ?? button.Action;
+        
+        switch (button.Alignment)
+        {
+            case TaskbarButtonAlignment.Left:
+                leftFlow.Add(button);
+                break;
+            case TaskbarButtonAlignment.Right:
+                rightFlow.Add(button);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+}

--- a/Kumi.Game/Screens/LoaderScreen.cs
+++ b/Kumi.Game/Screens/LoaderScreen.cs
@@ -41,14 +41,14 @@ public partial class LoaderScreen : KumiScreen
         });
     }
 
-    public override bool OnExiting(ScreenExitEvent e)
+    public override void OnSuspending(ScreenTransitionEvent e)
     {
         logo.FadeOut(1000, Easing.OutQuint);
         logo.ScaleTo(0.2f, 1000, Easing.OutQuint);
         loadAnimation.FadeOut(1000, Easing.OutQuint);
         loadAnimation.ScaleTo(0.2f, 1000, Easing.OutQuint);
-
-        return base.OnExiting(e);
+        
+        base.OnSuspending(e);
     }
 
     public void SetProgress(float progress)

--- a/Kumi.Game/Screens/Menu/MenuScreen.cs
+++ b/Kumi.Game/Screens/Menu/MenuScreen.cs
@@ -1,3 +1,4 @@
+using Kumi.Game.Graphics;
 using Kumi.Game.Graphics.Backgrounds;
 using Kumi.Game.Overlays;
 using Kumi.Game.Screens.Backgrounds;
@@ -63,6 +64,15 @@ public partial class MenuScreen : KumiScreen
                     Horizontal = 32,
                     Vertical = 40
                 }
+            },
+            new SpriteText
+            {
+                Shadow = true,
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                Y = -32,
+                Text = "Press any key",
+                Font = KumiFonts.GetFont(size: 20)
             }
         });
     }

--- a/Kumi.Tests/Visual/Overlays/TaskbarTestScene.cs
+++ b/Kumi.Tests/Visual/Overlays/TaskbarTestScene.cs
@@ -1,0 +1,33 @@
+﻿using Kumi.Game.Overlays;
+using Kumi.Game.Tests;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+
+namespace Kumi.Tests.Visual.Overlays;
+
+public partial class TaskbarTestScene : KumiTestScene
+{
+    private TaskbarOverlay? overlay;
+
+    [SetUp]
+    public void Setup()
+    {
+        Scheduler.Add(() =>
+        {
+            Clear();
+            overlay?.Dispose();
+            overlay = new TaskbarOverlay();
+
+            Add(overlay);
+        });
+    }
+
+    [Test]
+    public void TaskbarTests()
+    {
+        AddToggleStep("toggle taskbar", v =>
+        {
+            overlay!.State.Value = v ? Visibility.Visible : Visibility.Hidden;
+        });
+    }
+}


### PR DESCRIPTION
- Prerequisite for #6 

![image](https://github.com/kikuyodev/kumi/assets/128853881/66f6d5f2-12e9-412b-ad6c-f23e5c86bf9d)

Some things are left for later, such as the actual registration page. I'm not entirely sure how I would want that to look just yet, but I'm thinking about something along the lines of being in the same flyout, but just pushing the login screen when the user wants to register (of course they will be able to go back to the login screen by clicking the back button on the top left of the flyout).

Don't worry about the disabled buttons, they'll enable once there's an action set for them.