### PR TITLE
Fix subscriptions not running

### DIFF
--- a/Kumi.Game/KumiGameBase.cs
+++ b/Kumi.Game/KumiGameBase.cs
@@ -62,7 +62,7 @@ public partial class KumiGameBase : osu.Framework.Game, ICanAcceptFiles
         loadFonts();
 
         // Realm Database, Storage, and Charts
-        DependencyContainer.Cache(realm = new RealmAccess(Storage!));
+        DependencyContainer.Cache(realm = new RealmAccess(Storage!, thread: Host.UpdateThread));
         DependencyContainer.CacheAs(Storage);
 
         // TODO

--- a/Kumi.Game/Tests/RealmTestGame.cs
+++ b/Kumi.Game/Tests/RealmTestGame.cs
@@ -49,7 +49,7 @@ public partial class RealmTestGame : osu.Framework.Game
             var defaultStorage = (Storage) Dependencies.Get(typeof(Storage));
             var testStorage = defaultStorage.GetStorageForDirectory("test");
 
-            using (var realm = new RealmAccess(testStorage, $"{Guid.NewGuid().ToString()}.realm"))
+            using (var realm = new RealmAccess(testStorage, $"{Guid.NewGuid().ToString()}.realm", Host.UpdateThread))
             {
                 Logger.Log($"Running test using realm file {testStorage.GetFullPath(realm.FileName)}");
                 testAction(realm, testStorage);
@@ -73,7 +73,7 @@ public partial class RealmTestGame : osu.Framework.Game
         {
             var testStorage = (Storage) Dependencies.Get(typeof(Storage));
 
-            using (var realm = new RealmAccess(testStorage, $"{Guid.NewGuid().ToString()}.realm"))
+            using (var realm = new RealmAccess(testStorage, $"{Guid.NewGuid().ToString()}.realm", Host.UpdateThread))
             {
                 Logger.Log($"Running test using realm file {testStorage.GetFullPath(realm.FileName)}");
                 await testAction(realm, testStorage);


### PR DESCRIPTION
This was largely caused by a lack of any synchronization between whatever thread `RealmAccess.Subscribe<T>()` gets ran on, and the fact that all realm updates are connected to the update thread.

Quite a tricky issue to spot, admittedly.