### PR TITLE
Add the rest of notes to `Note.ToSaveableString()`

### DIFF
--- a/Kumi.Game/Extensions/NoteExtensions.cs
+++ b/Kumi.Game/Extensions/NoteExtensions.cs
@@ -9,6 +9,12 @@ public static class NoteExtensions
         if (note is DrumHit hit)
         {
             return $"{(int)hit.Type.Value}{Note.DELIMITER}{hit.StartTime}{Note.DELIMITER}{(int)hit.Flags.Value}";
+        } else if (note is DrumRoll roll)
+        {
+            return $"{(int)roll.Type.Value}{Note.DELIMITER}{roll.StartTime}{Note.DELIMITER}{roll.EndTime}{Note.DELIMITER}{(int)roll.Flags.Value}";
+        } else if (note is Balloon balloon)
+        {
+            return $"{(int)balloon.Type.Value}{Note.DELIMITER}{balloon.StartTime}{Note.DELIMITER}{balloon.EndTime}{Note.DELIMITER}{(int)balloon.Flags.Value}";
         }
 
         return "";


### PR DESCRIPTION
The lack of the rest of the notes made it impossible to copy certain notes.